### PR TITLE
Update Gen5TimerModel.cpp

### DIFF
--- a/src/models/timers/Gen5TimerModel.cpp
+++ b/src/models/timers/Gen5TimerModel.cpp
@@ -17,7 +17,7 @@ namespace model::timer {
 
         namespace Defaults {
             const int MODE = 0;
-            const int CALIBRATION = 95;
+            const int CALIBRATION = -95;
             const int FRAME_CALIBRATION = 0;
             const int ENTRALINK_CALIBRATION = 256;
             const int TARGET_DELAY = 1200;


### PR DESCRIPTION
This corrects the default Gen 5 calibration from 95 to -95 as it was in 2.0.1